### PR TITLE
SVCPLAN-1658: backup client

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"settings": {
 		"terminal.integrated.profiles.linux": {
 			"bash": {
-				"path": "bash",
+				"path": "bash"
 			}
 		}
 	},

--- a/.github/workflows/pdk-validate.yml
+++ b/.github/workflows/pdk-validate.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: "Clone repository"
-        uses: "actions/checkout@v2"
+        uses: "actions/checkout@v3"
       - name: "Run pdk validate"
         uses: "puppets-epic-show-theatre/action-pdk-validate@v1"
         with:

--- a/.pdkignore
+++ b/.pdkignore
@@ -39,7 +39,6 @@
 /rakelib/
 /.rspec
 /.rubocop.yml
-/.travis.yml
 /.yardopts
 /spec/
 /.vscode/

--- a/Gemfile
+++ b/Gemfile
@@ -13,22 +13,31 @@ def location_for(place_or_version, fake_version = nil)
   end
 end
 
-ruby_version_segments = Gem::Version.new(RUBY_VERSION.dup).segments
-minor_version = ruby_version_segments[0..1].join('.')
-
 group :development do
-  gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 2.8.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "puppet-module-posix-default-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-posix-dev-r#{minor_version}", '~> 1.0',     require: false, platforms: [:ruby]
-  gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "voxpupuli-puppet-lint-plugins", '>= 3.0',                 require: false
+  gem "json", '= 2.1.0',                           require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.3.0',                           require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.5.1',                           require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.1',                           require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "json", '= 2.6.3',                           require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "voxpupuli-puppet-lint-plugins", '~> 4.0',   require: false
+  gem "facterdb", '~> 1.18',                       require: false
+  gem "metadata-json-lint", '>= 2.0.2', '< 4.0.0', require: false
+  gem "puppetlabs_spec_helper", '~> 5.0',          require: false
+  gem "rspec-puppet-facts", '~> 2.0',              require: false
+  gem "codecov", '~> 0.2',                         require: false
+  gem "dependency_checker", '~> 0.2',              require: false
+  gem "parallel_tests", '= 3.12.1',                require: false
+  gem "pry", '~> 0.10',                            require: false
+  gem "simplecov-console", '~> 0.5',               require: false
+  gem "puppet-debugger", '~> 1.0',                 require: false
+  gem "rubocop", '= 1.6.1',                        require: false
+  gem "rubocop-performance", '= 1.9.1',            require: false
+  gem "rubocop-rspec", '= 2.0.1',                  require: false
+  gem "rb-readline", '= 0.5.5',                    require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
-  gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]
-  gem "puppet-module-win-system-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
+  gem "puppet_litmus", '< 1.0.0', require: false, platforms: [:ruby, :x64_mingw]
+  gem "serverspec", '~> 2.41',    require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/README.md
+++ b/README.md
@@ -5,13 +5,11 @@
 
 NCSA Common Puppet Profiles - configure NCSA Service backups
 
-> :warning: **This is work in progress**: Currently only the `::profile_backup::server` logic is functional.
 
 ## Table of Contents
 
 1. [Description](#description)
 1. [Setup - The basics of getting started with profile_backup](#setup)
-1. [Usage - Configuration options and additional functionality](#usage)
 1. [Dependencies](#dependencies)
 1. [Reference](#reference)
 
@@ -26,9 +24,33 @@ See https://wiki.ncsa.illinois.edu/display/ICI/NCSA+Service+Backups
 
 ### Backup Clients
 
-To setup a backup client include profile_backup in a puppet profile file for a service:
+Generally only clients that use a **puppet profile** class that needs backups should be configured for backups. 
+So to setup a backup client in a **puppet profile** class for a service 1) include `profile_backup::client` and 2) add a backup job:
 ```
 include ::profile_backup::client
+
+profile_backup::client::add_job { 'jobname':
+  paths             => [ '/directory1', '/tmp/directory2.tar', ],
+  prehook_commands  => 'tar cf /tmp/directory2.tar /directory2',
+  posthook_commands => 'rm -f /tmp/directory2.tar',
+}
+```
+
+The backup clients will need the following parameters supplied:
+```yaml
+profile_backup::client::encryption_passphrase: "CHANGE ME"  # PREFERABLY IN EYAML
+profile_backup::client::server_user: "backup"
+profile_backup::client::servers:
+  - "backup1.local"
+  - "backup2.local"
+profile_backup::client::ssh_key_priv: "SSH PRIVATE KEY CONTENTS"  # PREFERABLY IN EYAML
+profile_backup::client::ssh_key_pub:  "SSH PUBLIC KEY CONTENTS"   # PREFERABLY IN EYAML
+profile_backup::client::ssh_key_type: "ssh-ed25519"
+```
+
+If for some reason you want to disable backups, the following parameter should be set:
+```yaml
+profile_backup::client::enabled: false
 ```
 
 ### Backup Servers
@@ -53,11 +75,7 @@ profile_backup::server::uid: "9999"
 profile_backup::server::username: "backup"
 ```
 
-If multiple backup servers are setup, `$profile_backup::server::backup_directory` needs to be mounted from a remote or distributed filesystem. The `$profile_backup::server::allow_client_requires` parameter provides a way to add adhod resource requirements that can be used to ensure the remote filesystem is mounted before attempting to write to it.
-
-## Usage
-
-The goal is that no paramters are required to be set. The default paramters should work for most NCSA deployments out of the box.
+If multiple backup servers are setup, `$profile_backup::server::backup_directory` needs to be mounted from a remote or distributed filesystem. The `$profile_backup::server::allow_client_requires` parameter provides a way to add adhoc resource requirements that can be used to ensure the remote filesystem is mounted before attempting to write to it.
 
 
 ## Dependencies

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -7,13 +7,14 @@
 ### Classes
 
 * [`profile_backup`](#profile_backup): Install and configure NCSA Service Backups for clients and backup servers
-* [`profile_backup::client`](#profile_backupclient): Configure backup client
-* [`profile_backup::common`](#profile_backupcommon): Configure common things for both backup clients and servers.
-* [`profile_backup::server`](#profile_backupserver): Configure backup server
+* [`profile_backup::client`](#profile_backup--client): Configure backup client
+* [`profile_backup::common`](#profile_backup--common): Configure common things for both backup clients and servers.
+* [`profile_backup::server`](#profile_backup--server): Configure backup server
 
 ### Defined types
 
-* [`profile_backup::server::allow_client`](#profile_backupserverallow_client): Enable backup client to access backup server
+* [`profile_backup::client::add_job`](#profile_backup--client--add_job): Defined type to add a new service backup job
+* [`profile_backup::server::allow_client`](#profile_backup--server--allow_client): Enable backup client to access backup server
 
 ## Classes
 
@@ -34,7 +35,7 @@ should be included, depending on the role:
 include profile_backup::client
 ```
 
-### <a name="profile_backupclient"></a>`profile_backup::client`
+### <a name="profile_backup--client"></a>`profile_backup::client`
 
 Configure backup client
 
@@ -50,29 +51,85 @@ include profile_backup::client
 
 The following parameters are available in the `profile_backup::client` class:
 
-* [`ssh_key_priv`](#ssh_key_priv)
-* [`ssh_key_pub`](#ssh_key_pub)
-* [`ssh_key_type`](#ssh_key_type)
+* [`enabled`](#-profile_backup--client--enabled)
+* [`encryption_passphrase`](#-profile_backup--client--encryption_passphrase)
+* [`job_cron_schedule`](#-profile_backup--client--job_cron_schedule)
+* [`prune_settings`](#-profile_backup--client--prune_settings)
+* [`server_user`](#-profile_backup--client--server_user)
+* [`servers`](#-profile_backup--client--servers)
+* [`ssh_key_priv`](#-profile_backup--client--ssh_key_priv)
+* [`ssh_key_pub`](#-profile_backup--client--ssh_key_pub)
+* [`ssh_key_type`](#-profile_backup--client--ssh_key_type)
+* [`verify_cron_schedule`](#-profile_backup--client--verify_cron_schedule)
+* [`work_directory`](#-profile_backup--client--work_directory)
 
-##### <a name="ssh_key_priv"></a>`ssh_key_priv`
+##### <a name="-profile_backup--client--enabled"></a>`enabled`
+
+Data type: `Boolean`
+
+Abitilty to enable/disable backups
+
+##### <a name="-profile_backup--client--encryption_passphrase"></a>`encryption_passphrase`
+
+Data type: `String`
+
+Encryption passphrase used by the client's backups
+
+##### <a name="-profile_backup--client--job_cron_schedule"></a>`job_cron_schedule`
+
+Data type: `Hash`
+
+Cron settings for backup jobs
+
+##### <a name="-profile_backup--client--prune_settings"></a>`prune_settings`
+
+Data type: `Hash`
+
+Settings used for pruning client's backup data
+
+##### <a name="-profile_backup--client--server_user"></a>`server_user`
+
+Data type: `String`
+
+User that client connects to backup server as
+
+##### <a name="-profile_backup--client--servers"></a>`servers`
+
+Data type: `Array[String]`
+
+List of backup servers that client can backup to
+
+##### <a name="-profile_backup--client--ssh_key_priv"></a>`ssh_key_priv`
 
 Data type: `String`
 
 The private ssh key itself; generally a very long string...
 
-##### <a name="ssh_key_pub"></a>`ssh_key_pub`
+##### <a name="-profile_backup--client--ssh_key_pub"></a>`ssh_key_pub`
 
 Data type: `String`
 
 The public ssh key itself; generally a long string...
 
-##### <a name="ssh_key_type"></a>`ssh_key_type`
+##### <a name="-profile_backup--client--ssh_key_type"></a>`ssh_key_type`
 
 Data type: `String`
 
 The encryption type used in the ssh key.
 
-### <a name="profile_backupcommon"></a>`profile_backup::common`
+##### <a name="-profile_backup--client--verify_cron_schedule"></a>`verify_cron_schedule`
+
+Data type: `Hash`
+
+Cron settings for backup verification
+
+##### <a name="-profile_backup--client--work_directory"></a>`work_directory`
+
+Data type: `String`
+
+Directory path where backup scripts and jobs are located
+
+### <a name="profile_backup--common"></a>`profile_backup::common`
 
 Configure common things for both backup clients and servers.
 
@@ -88,29 +145,29 @@ include profile_backup::common
 
 The following parameters are available in the `profile_backup::common` class:
 
-* [`packages`](#packages)
-* [`pip_config`](#pip_config)
-* [`pip_proxy`](#pip_proxy)
+* [`packages`](#-profile_backup--common--packages)
+* [`pip_config`](#-profile_backup--common--pip_config)
+* [`pip_proxy`](#-profile_backup--common--pip_proxy)
 
-##### <a name="packages"></a>`packages`
+##### <a name="-profile_backup--common--packages"></a>`packages`
 
 Data type: `Hash`
 
 Packages to install to support the backup service.
 
-##### <a name="pip_config"></a>`pip_config`
+##### <a name="-profile_backup--common--pip_config"></a>`pip_config`
 
 Data type: `String`
 
 Path to pip config file
 
-##### <a name="pip_proxy"></a>`pip_proxy`
+##### <a name="-profile_backup--common--pip_proxy"></a>`pip_proxy`
 
 Data type: `String`
 
 Optional proxy server for pip configuration
 
-### <a name="profile_backupserver"></a>`profile_backup::server`
+### <a name="profile_backup--server"></a>`profile_backup::server`
 
 Configure backup server
 
@@ -126,23 +183,23 @@ include profile_backup::server
 
 The following parameters are available in the `profile_backup::server` class:
 
-* [`additional_sshd_match_params`](#additional_sshd_match_params)
-* [`allow_client_requires`](#allow_client_requires)
-* [`backup_directory`](#backup_directory)
-* [`clients`](#clients)
-* [`gid`](#gid)
-* [`groupname`](#groupname)
-* [`uid`](#uid)
-* [`username`](#username)
+* [`additional_sshd_match_params`](#-profile_backup--server--additional_sshd_match_params)
+* [`allow_client_requires`](#-profile_backup--server--allow_client_requires)
+* [`backup_directory`](#-profile_backup--server--backup_directory)
+* [`clients`](#-profile_backup--server--clients)
+* [`gid`](#-profile_backup--server--gid)
+* [`groupname`](#-profile_backup--server--groupname)
+* [`uid`](#-profile_backup--server--uid)
+* [`username`](#-profile_backup--server--username)
 
-##### <a name="additional_sshd_match_params"></a>`additional_sshd_match_params`
+##### <a name="-profile_backup--server--additional_sshd_match_params"></a>`additional_sshd_match_params`
 
 Data type: `Hash`
 
 Hash of additional sshd match parameters.
 Passed to `sshd::allow_from` defined type from `profile_backup::server::allow_client`.
 
-##### <a name="allow_client_requires"></a>`allow_client_requires`
+##### <a name="-profile_backup--server--allow_client_requires"></a>`allow_client_requires`
 
 Data type: `Array[String]`
 
@@ -154,19 +211,19 @@ be specified as a `require` array, e.g.:
 - "Package[package1]"
 ```
 
-##### <a name="backup_directory"></a>`backup_directory`
+##### <a name="-profile_backup--server--backup_directory"></a>`backup_directory`
 
 Data type: `String`
 
 Directory path where backups are stored for each client.
 
-##### <a name="clients"></a>`clients`
+##### <a name="-profile_backup--server--clients"></a>`clients`
 
 Data type: `Hash`
 
-Clients that need to be manually configured.
-Backup clients that are using the same Puppet server should not need to
-be added here as those are added via 'exported resources' via PuppetDB.
+Some clients will need to be manually configured for access to the servers.
+Backup clients that are using the same PuppetDB server as used by the backup servers should
+not need to be added here as those are added via 'exported resources'.
 This is a hash that contains all the parameters for `profile_backup::server::allow_client`:
 ```yaml
 profile_backup::server::clients:
@@ -177,25 +234,25 @@ profile_backup::server::clients:
     ssh_key_type: "ssh-rsa"  # ENCRYPTION TYPE
 ```
 
-##### <a name="gid"></a>`gid`
+##### <a name="-profile_backup--server--gid"></a>`gid`
 
 Data type: `String`
 
 Group id of user that owns backup files.
 
-##### <a name="groupname"></a>`groupname`
+##### <a name="-profile_backup--server--groupname"></a>`groupname`
 
 Data type: `String`
 
 Groupname that owns backup files.
 
-##### <a name="uid"></a>`uid`
+##### <a name="-profile_backup--server--uid"></a>`uid`
 
 Data type: `String`
 
 User id of user that owns backup files.
 
-##### <a name="username"></a>`username`
+##### <a name="-profile_backup--server--username"></a>`username`
 
 Data type: `String`
 
@@ -203,7 +260,54 @@ Username that owns backup files and allowed access.
 
 ## Defined types
 
-### <a name="profile_backupserverallow_client"></a>`profile_backup::server::allow_client`
+### <a name="profile_backup--client--add_job"></a>`profile_backup::client::add_job`
+
+Add a service backup job to this backup client
+
+#### Examples
+
+##### 
+
+```puppet
+profile_backup::client::add_job { 'jobname':
+  paths             => [ '/directory1', '/tmp/directory2.tar', ],
+  prehook_commands  => 'tar cf /tmp/directory2.tar /directory2',
+  posthook_commands => 'rm -f /tmp/directory2.tar',
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `profile_backup::client::add_job` defined type:
+
+* [`paths`](#-profile_backup--client--add_job--paths)
+* [`prehook_commands`](#-profile_backup--client--add_job--prehook_commands)
+* [`posthook_commands`](#-profile_backup--client--add_job--posthook_commands)
+
+##### <a name="-profile_backup--client--add_job--paths"></a>`paths`
+
+Data type: `Array[String]`
+
+List of directory paths for the job to backup.
+Can be a list of directories and/or specific files.
+
+##### <a name="-profile_backup--client--add_job--prehook_commands"></a>`prehook_commands`
+
+Data type: `Optional[String]`
+
+Optional commands to run before backup job
+
+Default value: `undef`
+
+##### <a name="-profile_backup--client--add_job--posthook_commands"></a>`posthook_commands`
+
+Data type: `Optional[String]`
+
+Optional commands to run after the backup job
+
+Default value: `undef`
+
+### <a name="profile_backup--server--allow_client"></a>`profile_backup::server::allow_client`
 
 Enable backup client to access backup server
 
@@ -224,30 +328,30 @@ profile_backup::server::allow_client { 'allow host hostname access to backup ser
 
 The following parameters are available in the `profile_backup::server::allow_client` defined type:
 
-* [`hostname`](#hostname)
-* [`ip`](#ip)
-* [`ssh_key_pub`](#ssh_key_pub)
-* [`ssh_key_type`](#ssh_key_type)
+* [`hostname`](#-profile_backup--server--allow_client--hostname)
+* [`ip`](#-profile_backup--server--allow_client--ip)
+* [`ssh_key_pub`](#-profile_backup--server--allow_client--ssh_key_pub)
+* [`ssh_key_type`](#-profile_backup--server--allow_client--ssh_key_type)
 
-##### <a name="hostname"></a>`hostname`
+##### <a name="-profile_backup--server--allow_client--hostname"></a>`hostname`
 
 Data type: `String`
 
 fqdn hostname of backup client.
 
-##### <a name="ip"></a>`ip`
+##### <a name="-profile_backup--server--allow_client--ip"></a>`ip`
 
 Data type: `String`
 
 ip of backup client.
 
-##### <a name="ssh_key_pub"></a>`ssh_key_pub`
+##### <a name="-profile_backup--server--allow_client--ssh_key_pub"></a>`ssh_key_pub`
 
 Data type: `String`
 
 The public ssh key itself; generally a long string...
 
-##### <a name="ssh_key_type"></a>`ssh_key_type`
+##### <a name="-profile_backup--server--allow_client--ssh_key_type"></a>`ssh_key_type`
 
 Data type: `String`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,4 +1,27 @@
 ---
+profile_backup::client::enabled: true
+profile_backup::client::encryption_passphrase: "CHANGE ME"
+profile_backup::client::job_cron_schedule:
+  hour: 0
+  minute: 30
+profile_backup::client::prune_settings:
+  "keep-hourly": 1
+  "keep-daily": 7
+  "keep-weekly": 4
+  "keep-monthly": 6
+  "keep-yearly": 2
+profile_backup::client::server_user: "svcncsaservicebackup"
+profile_backup::client::servers:
+  - "asd-backup01.internal.ncsa.edu"
+  - "asd-backup02.internal.ncsa.edu"
+  - "asd-backup03.internal.ncsa.edu"
+  - "asd-backup04.internal.ncsa.edu"
+profile_backup::client::ssh_key_type: "ssh-rsa"
+profile_backup::client::verify_cron_schedule:
+  hour: 5
+  minute: 0
+profile_backup::client::work_directory: "/root/backup"
+
 profile_backup::common::packages:
   "gcc-c++":
   "libacl":
@@ -6,7 +29,6 @@ profile_backup::common::packages:
   "libzstd-devel":
   "lz4-devel":
   "openssl-devel":
-  #"xxhash-devel":  # NOT AVAILABLE FOR RHEL. borg BUILD PROCESS WILL INCLUDE OWN COPY IF NOT PROVIDED BY OS
   "python3":
   "python3-devel":
   "python3-pip":
@@ -26,7 +48,6 @@ profile_backup::common::packages:
       - "Package[libzstd-devel]"
       - "Package[lz4-devel]"
       - "Package[openssl-devel]"
-      #- "Package[xxhash-devel]"
       - "Package[pkgconfig]"
       - "Package[setuptools-scm]"
 profile_backup::common::pip_config: "/etc/pip.conf"
@@ -42,12 +63,6 @@ profile_backup::server::additional_sshd_match_params:
 profile_backup::server::allow_client_requires: []
 profile_backup::server::backup_directory: null
 profile_backup::server::clients: {}
-#profile_backup::server::clients:
-#  "example client 1":
-#    hostname: "client1.local"
-#    ip: "127.0.0.1"
-#    ssh_key_pub: "AAAAB..."
-#    ssh_key_type: "ssh-rsa"
 profile_backup::server::gid: null
 profile_backup::server::groupname: "nobody"
 profile_backup::server::storage_dependencies: []

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,5 +1,23 @@
 # @summary Configure backup client
 #
+# @param enabled
+#   Abitilty to enable/disable backups
+#
+# @param encryption_passphrase
+#   Encryption passphrase used by the client's backups
+#
+# @param job_cron_schedule
+#   Cron settings for backup jobs
+#
+# @param prune_settings
+#   Settings used for pruning client's backup data
+#
+# @param server_user
+#   User that client connects to backup server as
+#
+# @param servers
+#   List of backup servers that client can backup to
+#
 # @param ssh_key_priv
 #   The private ssh key itself; generally a very long string...
 #
@@ -9,27 +27,163 @@
 # @param ssh_key_type
 #   The encryption type used in the ssh key.
 #
+# @param verify_cron_schedule
+#   Cron settings for backup verification
+#
+# @param work_directory
+#   Directory path where backup scripts and jobs are located
+#
 # @example
 #   include profile_backup::client
 class profile_backup::client (
+  Boolean $enabled,
+  String $encryption_passphrase,
+  Hash $job_cron_schedule,
+  Hash $prune_settings,
+  String $server_user,
+  Array[String] $servers,
   String $ssh_key_priv,
   String $ssh_key_pub,
   String $ssh_key_type,
+  Hash $verify_cron_schedule,
+  String $work_directory,
 ) {
-  include profile_backup::common
+  if ( $enabled) {
+    include profile_backup::common
 
-  ## TO DO...
-  # ENSURE $ssh_key_priv
-  # ENSURE $ssh_key_pub
-  # ENSURE ENCRYPTION KEY
-  # ...
+    # Local variables
+    $sshdir = '/root/.ssh'
+    $telegraf_interval = '1h'
+    $telegraf_interval_date_string = '1 hour ago'
 
-  # EXPORT CLIENT DETAILS TO BACKUP SERVER FOR ACCESS
-  @@profile_backup::server::allow_client { "allow host ${facts['networking']['fqdn']} access to backup servers":
-    hostname     => $facts['networking']['fqdn'],
-    ip           => $facts['networking']['ip'],
-    ssh_key_pub  => $ssh_key_pub,
-    ssh_key_type => $ssh_key_type,
-    tag          => 'profile_backup_allow_client',
+    # PREDICTIVELY RANDOMIZE LIST OF BACKUP $servers
+    $server_random_order_based_on_fqdn = fqdn_rotate($servers, $facts['networking']['mac'])
+    $server_list = $server_random_order_based_on_fqdn.join(' ')
+
+    $ssh_file_defaults = {
+      ensure  => file,
+      owner   => root,
+      group   => root,
+      mode    => '0600',
+      require => File[$sshdir],
+    }
+
+    # Define unique parameters of each resource
+    $ssh_file_data = {
+      $work_directory => {
+        ensure => directory,
+        mode   => '0700',
+        require => [],
+      },
+      $sshdir => {
+        ensure => directory,
+        mode   => '0700',
+        require => [],
+      },
+      "${sshdir}/backup_id_${ssh_key_type}" => {
+        content => Sensitive($ssh_key_priv),
+      },
+      "${sshdir}/backup_id_${ssh_key_type}.pub" => {
+        content => Sensitive("${ssh_key_type} ${ssh_key_pub} backup@${facts['networking']['fqdn']}\n"),
+        mode    => '0644',
+      },
+    }
+
+    # Ensure the ssh file resources
+    ensure_resources( 'file', $ssh_file_data, $ssh_file_defaults )
+
+    # Ensure borg_defaults file and settings
+    # CONVERT $prune_settings HASH TO $prune_options_string
+    $prune_options_string = $prune_settings
+    .map | $key, $value | { "--${key} ${value}" }
+    .join(' ')
+
+    $backup_file_defaults = {
+      ensure  => file,
+      owner   => root,
+      group   => root,
+      mode    => '0700',
+      require => File[$work_directory],
+    }
+
+    # Define unique parameters of each resource
+    $backup_file_data = {
+      $work_directory => {
+        ensure => directory,
+        require => [],
+      },
+      "${work_directory}/borg_defaults.sh" => {
+        content => template('profile_backup/borg_defaults.sh.erb'),
+      },
+      "${work_directory}/borg_check.sh" => {
+        content => template('profile_backup/borg_check.sh.erb'),
+      },
+      "${work_directory}/borg_list.sh" => {
+        content => template('profile_backup/borg_list.sh.erb'),
+      },
+      "${work_directory}/borg_backup_job.sh" => {
+        content => template('profile_backup/borg_backup_job.sh.erb'),
+      },
+      "${work_directory}/cron_do_backup.sh" => {
+        content => template('profile_backup/cron_do_backup.sh.erb'),
+      },
+      "${work_directory}/cron_check_backup.sh" => {
+        content => template('profile_backup/cron_check_backup.sh.erb'),
+      },
+    }
+    # Ensure the backup file resources
+    ensure_resources( 'file', $backup_file_data, $backup_file_defaults )
+
+    # SETUP RSYSLOG TO WATCH THE last_run FILES
+
+    # MONITORING VIA TELEGRAF
+    file { '/etc/telegraf/scripts/backup.sh':
+      ensure  => file,
+      owner   => 'root',
+      group   => 'telegraf',
+      mode    => '0750',
+      content => template('profile_backup/telegraf_backup.sh.erb'),
+    }
+    telegraf::input { 'backup':
+      plugin_type => 'exec',
+      options     => [
+        {
+          command     => '/etc/telegraf/scripts/backup.sh',
+          data_format => 'influx',
+          interval    => $telegraf_interval,
+          timeout     => '30s',
+        },
+      ],
+      require     => [
+        File['/etc/telegraf/scripts/backup.sh'],
+      ],
+    }
+
+    # EXPORT CLIENT DETAILS TO BACKUP SERVER FOR ACCESS
+    @@profile_backup::server::allow_client { "allow host ${facts['networking']['fqdn']} access to backup servers":
+      hostname     => $facts['networking']['fqdn'],
+      ip           => $facts['networking']['ip'],
+      ssh_key_pub  => $ssh_key_pub,
+      ssh_key_type => $ssh_key_type,
+      tag          => 'profile_backup_allow_client',
+    }
+
+    $cron_ensure = 'present'
+  } else {
+    $cron_ensure = 'absent'
+  }
+
+  # BACKUP CRONS
+
+  cron { 'profile_backup verify':
+    ensure  => $cron_ensure,
+    command => "${work_directory}/cron_check_backup.sh",
+    *       => $verify_cron_schedule,
+  }
+
+  cron { 'profile_backup backup jobs':
+    ensure  => $cron_ensure,
+    command => "${work_directory}/cron_do_backup.sh",
+    *       => $job_cron_schedule,
   }
 }

--- a/manifests/client/add_job.pp
+++ b/manifests/client/add_job.pp
@@ -1,0 +1,37 @@
+# @summary Defined type to add a new service backup job
+#
+# Add a service backup job to this backup client
+#
+# @param paths
+#   List of directory paths for the job to backup.
+#   Can be a list of directories and/or specific files.
+#
+# @param prehook_commands
+#   Optional commands to run before backup job
+#
+# @param posthook_commands
+#   Optional commands to run after the backup job
+#
+# @example
+#   profile_backup::client::add_job { 'jobname':
+#     paths             => [ '/directory1', '/tmp/directory2.tar', ],
+#     prehook_commands  => 'tar cf /tmp/directory2.tar /directory2',
+#     posthook_commands => 'rm -f /tmp/directory2.tar',
+#   }
+define profile_backup::client::add_job (
+  Array[String] $paths,
+  Optional[String] $prehook_commands = undef,
+  Optional[String] $posthook_commands = undef,
+) {
+  $backup_paths = $paths.join(' ')
+  $work_directory = $profile_backup::client::work_directory
+
+  file { "${work_directory}/backup_job_${name}.sh":
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0700',
+    content => template('profile_backup/backup_job.sh.erb'),
+    require => File[$profile_backup::client::work_directory],
+  }
+}

--- a/manifests/server/allow_client.pp
+++ b/manifests/server/allow_client.pp
@@ -38,7 +38,7 @@ define profile_backup::server::allow_client (
   # SETUP SSH AUTHORIZED KEY ENTRY FOR CLIENT
   ssh_authorized_key { $hostname:
     ensure  => present,
-    key     => $ssh_key_pub,
+    key     => Sensitive($ssh_key_pub),
     # SEE https://borgbackup.readthedocs.io/en/stable/quickstart.html#remote-repositories
     options => [
       "from=\"${ip}\"",

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
       "version_requirement": ">= 6.21.0 < 8.0.0"
     }
   ],
-  "pdk-version": "2.5.0",
-  "template-url": "pdk-default#2.5.0",
-  "template-ref": "tags/2.5.0-0-g369d483"
+  "pdk-version": "2.7.1",
+  "template-url": "pdk-default#2.7.4",
+  "template-ref": "tags/2.7.4-0-g58edf57"
 }

--- a/spec/defines/client/add_job_spec.rb
+++ b/spec/defines/client/add_job_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'profile_backup::client::add_job' do
+  let(:title) { 'namevar' }
+  let(:params) do
+    {}
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/templates/backup_job.sh.erb
+++ b/templates/backup_job.sh.erb
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This file is managed by Puppet.
+# Backup job script for job: <%= @name %>
+
+set -x
+
+<% if @prehook_commands -%>
+# COMMANDS TO RUN BEFORE BACKUP
+<%= @prehook_commands %>
+<% end -%>
+
+# BORG BACKUP OF <%= @name %>
+<%= @work_directory %>/borg_backup_job.sh --job <%= @name %> --paths '<%= @backup_paths %>'
+
+<% if @posthook_commands -%>
+# COMMANDS TO RUN AFTER BACKUP
+<%= @posthook_commands %>
+<% end -%>
+

--- a/templates/borg_backup_job.sh.erb
+++ b/templates/borg_backup_job.sh.erb
@@ -1,0 +1,123 @@
+#!/bin/sh
+# This file is managed by Puppet.
+# Adapted from https://borgbackup.readthedocs.io/en/stable/quickstart.html#automating-backups
+
+croak() {
+  logr "ERROR - $*"
+  echo "ERROR - $*"
+  exit 99
+}
+
+print_usage() {
+    cat <<ENDHERE
+Usage:
+    borg_backup_job [OPTIONS]
+
+OPTIONS:
+    -h | --help
+        Print usage message and exit
+    -j | --job <JOBNAME>
+        Name of backup job
+    -p | --paths '<BACKUPPATHS>'
+        Space delimited list of paths to directories or files to backup
+
+ENDHERE
+}
+
+# DO WORK
+ENDWHILE=0
+while [[ $# -gt 0 ]] && [[ $ENDWHILE -eq 0 ]] ; do
+  case $1 in
+    -h|--help)
+        print_usage
+        exit 0
+        ;;
+    -j|--job)
+        JOBNAME="$2"
+        shift
+        ;;
+    -p|--paths)
+        JOBPATHS="$2"
+        shift
+        ;;
+    --)
+        ENDWHILE=1
+        ;;
+    -*)
+        croak "Invalid option '$1'"
+        ;;
+     *)
+        ENDWHILE=1
+        break
+        ;;
+  esac
+  shift
+done
+
+if [ -z "$JOBNAME" ] || [ -z "$JOBPATHS" ]; then
+  echo "Error: you must supply both a job name and paths to backup."
+  print_usage
+  exit 0
+fi
+
+
+# LOAD CLIENT BORG DEFAULTS
+source <%= @work_directory %>/borg_defaults.sh
+
+# some helpers and error handling:
+#info() { printf "%s %s\n" "$( date ) ${JOBNAME}:" "$*" >&2; }
+trap 'echo $( date ) Backup interrupted >&2; exit 2' INT TERM
+
+echo "$JOBNAME backup paths: $JOBPATHS"
+
+# INITIALIZE REPO IF NECESSARY
+#$BORG echo &>/dev/null || ( echo "Setting up initial backup repository" ; $BORG init --encryption=repokey )
+$BORG init --encryption=repokey
+
+echo "$JOBNAME backup starting"
+
+# Backup the JOBPATHS into an archive named after JOBNAME and now timestamp
+$BORG create                         \
+    --verbose                       \
+    --list                          \
+    --filter AME                    \
+    --show-rc                       \
+    --compression lz4               \
+    ::"${JOBNAME}-{now}"            \
+    $JOBPATHS
+backup_exit=$?
+
+if [ ${backup_exit} -eq 0 ]; then
+    echo "$JOBNAME backup finished successfully"
+elif [ ${backup_exit} -eq 1 ]; then
+    echo "$JOBNAME backup finished with warnings"
+else
+    echo "$JOBNAME backup finished with errors"
+fi
+
+echo "$JOBNAME pruning repository"
+
+# Use the `prune` subcommand to maintain archive according to $BORG_PRUNE_OPTIONS
+# The '${JOBNAME}-*' matching is very important to limit prune's operation
+# to this JOBNAME's archives and not apply to other archives also:
+
+$BORG prune                          \
+    --list                          \
+    --glob-archives "${JOBNAME}-*"  \
+    --show-rc                       \
+    $BORG_PRUNE_OPTIONS
+
+prune_exit=$?
+
+if [ ${prune_exit} -eq 0 ]; then
+    echo "$JOBNAME prune finished successfully"
+elif [ ${prune_exit} -eq 1 ]; then
+    echo "$JOBNAME prune finished with warnings"
+else
+    echo "$JOBNAME prune finished with errors"
+fi
+
+# use highest exit code as global exit code
+global_exit=$(( backup_exit > prune_exit ? backup_exit : prune_exit ))
+
+exit ${global_exit}

--- a/templates/borg_check.sh.erb
+++ b/templates/borg_check.sh.erb
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This file is managed by Puppet.
+
+# ONLY RUN IF backup_job_* JOBS ARE PRESENT
+if find <%= @work_directory %>/backup_job_* -maxdepth 1 -type f 2>/dev/null | grep -q . ; then
+
+  # LOAD CLIENT BORG DEFAULTS
+  source <%= @work_directory %>/borg_defaults.sh
+
+  # Temporarily turned off --verify-data option as very slow.
+  # https://borgbackup.readthedocs.io/en/stable/usage/check.html
+  #$BORG check --show-rc --verify-data --verbose
+  $BORG check --show-rc --verbose
+
+  check_exit=$?
+        
+  if [ ${check_exit} -eq 0 ]; then
+    echo "Check finished successfully"
+  elif [ ${check_exit} -eq 1 ]; then
+    echo "Check finished with warnings"
+  else 
+    echo "Check finished with errors"
+  fi
+
+  exit ${check_exit}
+fi

--- a/templates/borg_defaults.sh.erb
+++ b/templates/borg_defaults.sh.erb
@@ -1,0 +1,32 @@
+#!/bin/sh
+# This file is managed by Puppet.
+
+REPOPATH='backups/<%= @facts['networking']['fqdn'] %>'
+BACKUPUSER='<%= @server_user %>'
+export BORG='/usr/local/bin/borg'
+export BORG_RSH='ssh -i <%= @sshdir %>/backup_id_<%= @ssh_key_type %> -o StrictHostKeyChecking=no'
+export BORG_PASSPHRASE='<%= @encryption_passphrase %>'
+export BORG_PRUNE_OPTIONS='<%= @prune_options_string %>'
+export BORG_RELOCATED_REPO_ACCESS_IS_OK=yes
+
+SERVER_LIST='<%= @server_list %>'
+# CHOOSE BACKUP SERVER THAT IS RESPONDING
+for SERVER in $SERVER_LIST; do
+  REPO="ssh://${BACKUPUSER}@${SERVER}/${REPOPATH}"
+  # IF THIS IS FIRST EVER RUN, NEED TO RUN borg init
+  if $BORG init --encryption=repokey ${REPO} &>/dev/null; then
+    BACKUP_SERVER=$SERVER
+    break
+  # IF REPO ALREADY EXISTS, NEED TO RUN borg info
+  elif $BORG info ${REPO} &>/dev/null; then
+    BACKUP_SERVER=$SERVER
+    break
+  fi
+done
+
+if [ -z "$BACKUP_SERVER" ]; then
+  echo "ERROR: No backup servers (<%= @server_list %>) are responding via SSH."
+  exit
+else
+  export BORG_REPO="ssh://${BACKUPUSER}@${BACKUP_SERVER}/${REPOPATH}"
+fi

--- a/templates/borg_list.sh.erb
+++ b/templates/borg_list.sh.erb
@@ -1,0 +1,19 @@
+#!/bin/sh
+# This file is managed by Puppet.
+
+# LOAD CLIENT BORG DEFAULTS
+source <%= @work_directory %>/borg_defaults.sh
+
+$BORG list
+
+list_exit=$?
+
+if [ ${list_exit} -eq 0 ]; then
+    echo "List finished successfully"
+elif [ ${list_exit} -eq 1 ]; then
+    echo "List finished with warnings"
+else
+    echo "List finished with errors"
+fi
+
+exit ${list_exit}

--- a/templates/cron_check_backup.sh.erb
+++ b/templates/cron_check_backup.sh.erb
@@ -1,0 +1,9 @@
+#!/bin/bash
+# This file is managed by Puppet.
+# CRON Script to check and verify backup repo and archives
+
+LAST_RUN='/var/log/backup_check_last_run'
+
+/root/backup/borg_check.sh 2>&1 | tee $LAST_RUN | logger -s -t backup_check
+
+# rsyslog WILL BE CONFIGURED TO WATCH $last_run FILE

--- a/templates/cron_do_backup.sh.erb
+++ b/templates/cron_do_backup.sh.erb
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This file is managed by Puppet.
+# CRON Script to process all backup job scripts
+
+BACKUP_JOBS=$(ls -1 <%= @work_directory %>/backup_job_*.sh)
+LAST_RUN='/var/log/backup_last_run'
+
+if [ ! -z "$BACKUP_JOBS" ]; then
+  # CLEAR LAST RUN FILE
+  echo -n "" > $LAST_RUN
+  for JOB in $BACKUP_JOBS; do
+    $JOB 2>&1 | tee -a $LAST_RUN | logger -s -t backup
+  done
+fi
+
+# rsyslog WILL BE CONFIGURED TO WATCH $last_run FILE

--- a/templates/telegraf_backup.sh.erb
+++ b/templates/telegraf_backup.sh.erb
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# STATUS OF BACKUP JOBS
+
+backup_run_file='/var/log/backup_last_run'
+#host=$(hostname -f)
+
+if [ -s "$backup_run_file" ] ; then
+  # FILE $backup_run_file IS NOT EMPTY AND EXISTS
+
+  backup_run_file_timestamp_string=$( stat $backup_run_file | grep 'Modify: ' | cut -d' ' -f2,3,4 )
+  backup_run_file_timestamp_epoch=$( date --date="${backup_run_file_timestamp_string}" +%s )
+  lastrun_timestamp_epoch=$( date --date="<%= @telegraf_interval_date_string %>" +%s )
+
+  if [ $backup_run_file_timestamp_epoch -ge $lastrun_timestamp_epoch ] ; then
+    archives_created=$( grep -i 'Creating archive' $backup_run_file | wc -l )
+    archives_kept=$( grep -i 'Keeping archive' $backup_run_file | wc -l )
+    archives_pruned=$( grep -i 'Pruning archive' $backup_run_file | wc -l )
+    backup_jobs=$( grep -i 'backup starting' $backup_run_file | wc -l )
+    backup_return_code=$( grep -i -B1 'backup finished' $backup_run_file | grep -i terminating | grep rc | awk '{ print $NF }' | sort -rn | head -n1 )
+    files_added=$( egrep '^A /' $backup_run_file | wc -l )
+    files_changed_in_process=$( egrep '^C /' $backup_run_file | wc -l )
+    files_errored=$( egrep '^E /' $backup_run_file | wc -l )
+    files_modified=$( egrep '^M /' $backup_run_file | wc -l )
+    #files_unchanged=$( egrep '^U /' $backup_run_file | wc -l )
+    prune_return_code=$( grep -i -B1 'prune finished' $backup_run_file | grep -i terminating | grep rc | awk '{ print $NF }' | sort -rn | head -n1 )
+    backup_run_file_timestamp_epoch_ns="${backup_run_file_timestamp_epoch}000000000"
+
+    echo "backup archives_created=${archives_created},archives_kept=${archives_kept},archives_pruned=${archives_pruned},backup_jobs=${backup_jobs},backup_return_code=${backup_return_code},files_added=${files_added},files_changed_in_process=${files_changed_in_process},files_errored=${files_errored},files_modified=${files_modified},prune_return_code=${prune_return_code} $backup_run_file_timestamp_epoch_ns"
+  fi
+
+  # GET LATEST BACKUP TIMES FOR EACH BACKUP JOB
+  now_timestamp_epoch=$( date +%s )
+  lastest_archives=$(grep -i 'Keeping archive' $backup_run_file | awk '{ print $3 }' | uniq -w 8)
+  for archive in $lastest_archives; do
+    backup_job=$(echo ${archive} | awk -F\- '{ print $1 }')
+    archive_timestamp_string=${archive#*-}
+    timezone=$(date +%z)
+    archive_timestamp_epoch=$( date --date="${archive_timestamp_string}${timezone}" +%s )
+    archive_age_seconds=$((now_timestamp_epoch-archive_timestamp_epoch))
+    echo "backup_age,backup_job=${backup_job} timestamp=${archive_timestamp_epoch}000000000,age=${archive_age_seconds}"
+  done
+
+fi
+
+# STATUS OF BACKUP CHECK
+
+backup_check_file='/var/log/backup_check_last_run'
+
+if [ -s "$backup_check_file" ] ; then
+  # FILE $backup_check_file IS NOT EMPTY AND EXISTS
+
+  backup_check_file_timestamp_string=$( stat $backup_check_file | grep 'Modify: ' | cut -d' ' -f2,3,4 )
+  backup_check_file_timestamp_epoch=$( date --date="${backup_check_file_timestamp_string}" +%s )
+
+  if [ $backup_check_file_timestamp_epoch -ge $lastrun_timestamp_epoch ] ; then
+    return_code=$( grep -i 'terminating with' $backup_check_file | grep rc | awk '{ print $NF }' )
+    repository_error=$( grep -i repository $backup_check_file | grep -i check | grep -i complete | grep -i found | egrep -vi ' no ' | wc -l )
+    archive_error=$( grep -i archive $backup_check_file | grep -i check | grep -i complete | grep -i found | egrep -vi ' no ' | wc -l )
+    chunks_missing=$( grep -i 'chunk missing' $backup_check_file | wc -l )
+    integrity_errors=$( grep -i 'integrity error' $backup_check_file | wc -l )
+    defect_chunks=$( grep -i 'defect chunk' $backup_check_file | wc -l )
+    backup_check_file_timestamp_epoch_ns="${backup_check_file_timestamp_epoch}000000000"
+
+    echo "backup_check return_code=${return_code},repository_error=${repository_error},archive_error=${archive_error},chunks_missing=${chunks_missing},integrity_errors=${integrity_errors},defect_chunks=${defect_chunks} $backup_check_file_timestamp_epoch_ns"
+  fi
+fi


### PR DESCRIPTION
```
Ensure ssh_keys on client
Fix pdk-validate github action
Choose random primary backup host
Create client::add_jobs defined type
Ensure borg_defaults.sh as an ERB template
Ensure borg_check.sh & borg_list.sh scripts from templates
Set BORG_RELOCATED_REPO_ACCESS_IS_OK=yes in borg_defaults.sh
Ensure borg_backup_job.sh script via template
Add backup verify cron
Add backup job cron
Add borg command path in defaults
Backup jobs use bash
More cron output to syslog, error output for borg list & check scripts
borg_backup_job reference JOBNAME in output
Add mac as custom seed for random server
Disable ssh StrictHostKeyChecking
Redirect cron output to null (since going to syslog too)
```

Basic functionality of the `profile_backup::client` class is functional. Additional functionality (e.g. telegraf monitoring, restore scripts, etc.) will come in [other planned tickets](https://jira.ncsa.illinois.edu/browse/SVCPLAN-1610).

This is being tested on `asd-prov01` & `git-test`, & `asd-pup01` with sample backup jobs.

Here are some details on how this is setup:
- see https://wiki.ncsa.illinois.edu/display/ICI/NCSA+Service+Backups
- backup scripts are under `/root/backup`
- there are 2 CRONs under root that include the name `profile_backup`
- all backup CRON output goes to syslog with the tag `backup`
- to list current backup archives run `/root/backup/borg_list.sh` on the client

@v1peractual since you have previous experience with Borg, I'd value your review of how I'm using the `/root/backup/borg_defaults.sh` file, creating the `/root/backup/backup_job_*.sh` files, and handling logging to syslog (via `logger`).