### PR TITLE
Backup CMD job and sanitize job names

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ if ( lookup('profile_backup::client::enabled') ) {
 }
 ```
 
+In instances where data is read from STDOUT when a command is ran (mysql dump), the class add_cmd_job.
+
+```
+profile_backup::client::add_cmd_job { "mysql_all_databases":
+  backup_command  => "${backup_cmd} ${backup_cmd_options} --all-databases",
+  filename => "mysql_all_databases.dump",
+
+```
+
+
 The backup clients will need the following parameters supplied:
 ```yaml
 profile_backup::client::encryption_passphrase: "CHANGE ME"  # PREFERABLY IN EYAML

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -277,9 +277,16 @@ profile_backup::client::add_job { 'jobname':
 }
 ```
 
-### <a name="profile_backup--client--add_cmd_job"></a>`profile_backup::client::add_job`
+### <a name="profile_backup--client--add_cmd_job"></a>`profile_backup::client::add_cmd_job`
 
 Add a service backup job to this backup client
+
+Add a service cmd backup job to this backup client
+This allows the streaming of data (STDOUT) directly to
+the backup without staging data to a file first. An example
+for the use would be to eliminate the need for a large database
+to be stored locally before being backed up.
+
 
 #### Examples
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -14,6 +14,7 @@
 ### Defined types
 
 * [`profile_backup::client::add_job`](#profile_backup--client--add_job): Defined type to add a new service backup job
+* [`profile_backup::client::add_cmd_job`](#profile_backup--client--add_cmd_job): Defined type to add a new service cmd backup job
 * [`profile_backup::server::allow_client`](#profile_backup--server--allow_client): Enable backup client to access backup server
 
 ## Classes
@@ -276,6 +277,24 @@ profile_backup::client::add_job { 'jobname':
 }
 ```
 
+### <a name="profile_backup--client--add_cmd_job"></a>`profile_backup::client::add_job`
+
+Add a service backup job to this backup client
+
+#### Examples
+
+##### 
+
+```puppet
+profile_backup::client::add_cmd_job { 'jobname':
+  backup_command    => 'mysqldump --single-transaction mydatabase',
+  filename          => 'mydatabase.dump',  
+  prehook_commands  => 'tar cf /tmp/directory2.tar /directory2',
+  posthook_commands => 'rm -f /tmp/directory2.tar',
+}
+```
+
+
 #### Parameters
 
 The following parameters are available in the `profile_backup::client::add_job` defined type:
@@ -304,6 +323,41 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 Optional commands to run after the backup job
+
+Default value: `undef`
+
+The following parameters are available in the `profile_backup::client::add_cmd_job` defined type:
+
+* [`command`](#-profile_backup--client--add_cmd_job--command)
+* [`filename`](#-profile_backup--client--add_cmd_job--filename)
+* [`prehook_commands`](#-profile_backup--client--add_job--prehook_commands)
+* [`posthook_commands`](#-profile_backup--client--add_job--posthook_commands)
+
+##### <a name="-profile_backup--client--add_cmd_job--command"></a>`paths`
+
+Data type: `String`
+
+Command to be ran in which the STDOUT is captured and backed up
+
+##### <a name="-profile_backup--client--add_cmd_job--command"></a>`paths`
+
+Data type: `String`
+
+Name of the file within the archive to store the data from the command
+
+##### <a name="-profile_backup--client--add_cmd_job--prehook_commands"></a>`prehook_commands`
+
+Data type: `Optional[String]`
+
+Optional commands to run before cmd backup job
+
+Default value: `undef`
+
+##### <a name="-profile_backup--client--add_cmd_job--posthook_commands"></a>`posthook_commands`
+
+Data type: `Optional[String]`
+
+Optional commands to run after the cmd backup job
 
 Default value: `undef`
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -124,6 +124,9 @@ class profile_backup::client (
       "${work_directory}/borg_backup_job.sh" => {
         content => template('profile_backup/borg_backup_job.sh.erb'),
       },
+      "${work_directory}/borg_backup_cmd_job.sh" => {
+        content => template('profile_backup/borg_backup_cmd_job.sh.erb'),
+      },
       "${work_directory}/cron_do_backup.sh" => {
         content => template('profile_backup/cron_do_backup.sh.erb'),
       },

--- a/manifests/client/add_cmd_job.pp
+++ b/manifests/client/add_cmd_job.pp
@@ -21,11 +21,17 @@
 #   Optional list of commands to run after the backup job
 #
 # @example
-#   profile_backup::client::add_job { 'jobname':
-#     paths             => [ '/directory1', '/tmp/directory2.tar', ],
-#     prehook_commands  => [ 'tar cf /tmp/directory2.tar /directory2', ],
-#     posthook_commands => [ 'rm -f /tmp/directory2.tar', ],
+# 
+# This will dump the database to mydatabase.dump with the backup job name 
+# jobname. No space will be consumed on the localhost and the STDOUT of 
+# the mysqldump will be written to a file. 
+#
+#   profile_backup::client::add_cmd_job { 'jobname':
+#     backup_command    => 'mysqldump --single-transaction --all-databases',
+#     filename          => 'mydatabase.dump',
 #   }
+#
+
 define profile_backup::client::add_cmd_job (
   String $backup_command,
   String $filename,

--- a/manifests/client/add_cmd_job.pp
+++ b/manifests/client/add_cmd_job.pp
@@ -2,9 +2,13 @@
 #
 # Add a service backup job to this backup client
 #
-# @param paths
+# @param backup_command
 #   List of directory paths for the job to backup.
 #   Can be a list of directories and/or specific files.
+#
+# @param filename
+#   Name of the file created by the command located 
+#   within the archive.
 #
 # @param prehook_commands
 #   Optional list of commands to run before backup job
@@ -18,21 +22,20 @@
 #     prehook_commands  => [ 'tar cf /tmp/directory2.tar /directory2', ],
 #     posthook_commands => [ 'rm -f /tmp/directory2.tar', ],
 #   }
-define profile_backup::client::add_job (
-  Array[String] $paths,
+define profile_backup::client::add_cmd_job (
+  String $backup_command,
+  String $filename,
   Optional[Array[String]] $prehook_commands = undef,
   Optional[Array[String]] $posthook_commands = undef,
 ) {
-  $backup_paths = $paths.join(' ')
   $work_directory = $profile_backup::client::work_directory
-
   $sanitizedname = regsubst($name,'[\-]','_','G')
   file { "${work_directory}/backup_job_${sanitizedname}.sh":
     ensure  => file,
     owner   => 'root',
     group   => 'root',
     mode    => '0700',
-    content => template('profile_backup/backup_job.sh.erb'),
+    content => template('profile_backup/backup_cmd_job.sh.erb'),
     require => File[$profile_backup::client::work_directory],
   }
 }

--- a/manifests/client/add_cmd_job.pp
+++ b/manifests/client/add_cmd_job.pp
@@ -1,6 +1,10 @@
-# @summary Defined type to add a new service backup job
+# @summary Defined type to add a new service backup cmd job
 #
-# Add a service backup job to this backup client
+# Add a service cmd backup job to this backup client
+# This allows the streaming of data (STDOUT) directly to
+# the backup without staging data to a file first. An example
+# for the use would be to eliminate the need for a large database
+# to be stored locally before being backed up.
 #
 # @param backup_command
 #   List of directory paths for the job to backup.

--- a/templates/backup_cmd_job.sh.erb
+++ b/templates/backup_cmd_job.sh.erb
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This file is managed by Puppet.
+# Backup job script for job: <%= @name %>
+
+set -x
+
+<% if @prehook_commands -%>
+# COMMANDS TO RUN BEFORE BACKUP
+<%  @prehook_commands.each do |command| -%>
+<%= command %>
+<% end -%>
+<% end -%>
+
+# BORG BACKUP OF <%= @name %>
+<%= @work_directory %>/borg_backup_cmd_job.sh --job <%= @name %> --command '<%= @backup_command %>' --filename <%= @filename %>
+
+<% if @posthook_commands -%>
+# COMMANDS TO RUN AFTER BACKUP
+<%  @posthook_commands.each do |command| -%>
+<%= command %>
+<% end -%>
+<% end -%>
+

--- a/templates/borg_backup_cmd_job.sh.erb
+++ b/templates/borg_backup_cmd_job.sh.erb
@@ -1,0 +1,133 @@
+#!/bin/sh
+# This file is managed by Puppet.
+# Adapted from https://borgbackup.readthedocs.io/en/stable/quickstart.html#automating-backups
+
+croak() {
+  logr "ERROR - $*"
+  echo "ERROR - $*"
+  exit 99
+}
+
+print_usage() {
+    cat <<ENDHERE
+Usage:
+    borg_backup_job [OPTIONS]
+
+OPTIONS:
+    -h | --help
+        Print usage message and exit
+    -j | --job '<JOBNAME>'
+        Name of backup job
+    -c | --command '<COMMAND>'
+        The command that is ran and stdout is output to a backup
+    -f | --filename '<FILENAME>'
+        Name of the file the stdout of the command
+
+
+ENDHERE
+}
+
+# DO WORK
+ENDWHILE=0
+while [[ $# -gt 0 ]] && [[ $ENDWHILE -eq 0 ]] ; do
+  case $1 in
+    -h|--help)
+        print_usage
+        exit 0
+        ;;
+    -j|--job)
+        JOBNAME="$2"
+        shift
+        ;;
+    -c|--command)
+        COMMAND="$2"
+        shift
+        ;;
+    -f|--filename)
+        FILENAME="$2"
+        shift
+        ;;
+ 
+    --)
+        ENDWHILE=1
+        ;;
+    -*)
+        croak "Invalid option '$1'"
+        ;;
+     *)
+        ENDWHILE=1
+        break
+        ;;
+  esac
+  shift
+done
+
+if [ -z "$JOBNAME" ] || [ -z "$FILENAME" ] || [ -z "$COMMAND" ]; then
+  echo "Error: you must supply both a job name, a filename to output, and the command to backup."
+  print_usage
+  exit 0
+fi
+
+
+# LOAD CLIENT BORG DEFAULTS
+source <%= @work_directory %>/borg_defaults.sh
+
+# some helpers and error handling:
+#info() { printf "%s %s\n" "$( date ) ${JOBNAME}:" "$*" >&2; }
+trap 'echo $( date ) Backup interrupted >&2; exit 2' INT TERM
+
+echo "$JOBNAME backup command: $COMMAND"
+
+# INITIALIZE REPO IF NECESSARY
+#$BORG echo &>/dev/null || ( echo "Setting up initial backup repository" ; $BORG init --encryption=repokey )
+$BORG init --encryption=repokey
+
+echo "$JOBNAME backup starting"
+
+# Run the COMMAND and backup into an archive named after JOBNAME and now timestamp with the name
+$COMMAND |                          \
+  $BORG create                      \
+    --stdin-name $FILENAME          \
+    --verbose                       \
+    --list                          \
+    --filter AME                    \
+    --show-rc                       \
+    --compression lz4               \
+    ::"${JOBNAME}-{now}"            \
+    -
+backup_exit=$?
+
+if [ ${backup_exit} -eq 0 ]; then
+    echo "$JOBNAME backup finished successfully"
+elif [ ${backup_exit} -eq 1 ]; then
+    echo "$JOBNAME backup finished with warnings"
+else
+    echo "$JOBNAME backup finished with errors"
+fi
+
+echo "$JOBNAME pruning repository"
+
+# Use the `prune` subcommand to maintain archive according to $BORG_PRUNE_OPTIONS
+# The '${JOBNAME}-*' matching is very important to limit prune's operation
+# to this JOBNAME's archives and not apply to other archives also:
+
+$BORG prune                          \
+    --list                          \
+    --glob-archives "${JOBNAME}-*"  \
+    --show-rc                       \
+    $BORG_PRUNE_OPTIONS
+
+prune_exit=$?
+
+if [ ${prune_exit} -eq 0 ]; then
+    echo "$JOBNAME prune finished successfully"
+elif [ ${prune_exit} -eq 1 ]; then
+    echo "$JOBNAME prune finished with warnings"
+else
+    echo "$JOBNAME prune finished with errors"
+fi
+
+# use highest exit code as global exit code
+global_exit=$(( backup_exit > prune_exit ? backup_exit : prune_exit ))
+
+exit ${global_exit}


### PR DESCRIPTION
This commit is to add backup job using a command. The command will output to STDOUT and will be named within the archive via a variable. The names of the jobs (both cmd and files/directories) will be sanitized to change any dashes to underscores. This is to make sure any of the telegraf alerting is correctly parsed as the separator is a dash.

add the command job

put the command job script in place and name it with shorthand

remove paths

update reference

fix cmd

fix backup jobs

wrong name

syntax

sanitize for dashes

attempt to sanitize job name

attempt to sanitize job name

attempt to sanitize job name

attempt to sanitize job name

attempt to sanitize job name

attempt to sanitize job name

attempt to sanitize job name

attempt to sanitize job name

attempt to sanitize job name

fix readme

fix REF