### PR TITLE
SVCPLAN-5100: Add backup user to local group

### DIFF
--- a/.pdkignore
+++ b/.pdkignore
@@ -29,6 +29,7 @@
 /.fixtures.yml
 /Gemfile
 /.gitattributes
+/.github/
 /.gitignore
 /.pdkignore
 /.puppet-lint.rc

--- a/Gemfile
+++ b/Gemfile
@@ -34,11 +34,16 @@ group :development do
   gem "rubocop", '= 1.48.1',                     require: false
   gem "rubocop-performance", '= 1.16.0',         require: false
   gem "rubocop-rspec", '= 2.19.0',               require: false
+  gem "puppet-strings", '~> 4.0',                require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
 end
 group :system_tests do
   gem "puppet_litmus", '~> 1.0', require: false, platforms: [:ruby, :x64_mingw]
   gem "serverspec", '~> 2.41',   require: false
+end
+group :release_prep do
+  gem "puppet-strings", '~> 4.0',         require: false
+  gem "puppetlabs_spec_helper", '~> 6.0', require: false
 end
 
 puppet_version = ENV['PUPPET_GEM_VERSION']

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -54,11 +54,12 @@ profile_backup::common::pip_config: "/etc/pip.conf"
 profile_backup::common::pip_proxy: ""
 
 profile_backup::server::additional_sshd_match_params:
-  PubkeyAuthentication: "yes"
+  AllowGroups: "%{lookup('profile_backup::server::groupname')}"
   AuthenticationMethods: "publickey"
   Banner: "none"
   MaxAuthTries: "6"
   MaxSessions: "10"
+  PubkeyAuthentication: "yes"
   X11Forwarding: "no"
 profile_backup::server::allow_client_requires: []
 profile_backup::server::backup_directory: null

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -68,18 +68,21 @@ class profile_backup::server (
 
   # SETUP BACKUP USER & GROUP
   group { $groupname:
-    ensure => 'present',
-    gid    => $gid,
+    ensure     => 'present',
+    forcelocal => true,
+    gid        => $gid,
   }
 
   user { $username:
-    ensure   => 'present',
-    uid      => $uid,
-    gid      => $gid,
-    home     => $backup_directory,
-    password => '!!',
-    shell    => '/bin/bash',
-    comment  => 'NCSA Service Backups',
+    ensure     => 'present',
+    uid        => $uid,
+    forcelocal => true,
+    gid        => $gid,
+    groups     => [$groupname],
+    home       => $backup_directory,
+    password   => '!!',
+    shell      => '/bin/bash',
+    comment    => 'NCSA Service Backups',
   }
 
   # COLLECT EXPORTED RESOURCES FOR backup_allow_client_on_server

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
       "version_requirement": ">= 6.21.0 < 8.0.0"
     }
   ],
-  "pdk-version": "3.0.0",
-  "template-url": "pdk-default#3.0.0",
-  "template-ref": "tags/3.0.0-0-g056e50d"
+  "pdk-version": "3.0.1",
+  "template-url": "pdk-default#3.0.1",
+  "template-ref": "tags/3.0.1-0-gd13288a"
 }

--- a/spec/default_facts.yml
+++ b/spec/default_facts.yml
@@ -2,7 +2,8 @@
 #
 # Facts specified here will override the values provided by rspec-puppet-facts.
 ---
-ipaddress: "172.16.254.254"
-ipaddress6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+networking:
+  ip: "172.16.254.254"
+  ip6: "FE80:0000:0000:0000:AAAA:AAAA:AAAA"
+  mac: "AA:AA:AA:AA:AA:AA"
 is_pe: false
-macaddress: "AA:AA:AA:AA:AA:AA"


### PR DESCRIPTION
```
Force user and group to be local, and user member of group
Add AllowGroups to sshd config
```

This is being tested on `service-backup02` (RHEL 8.6) & `service-backup04` (RHEL 8.8).