### PR TITLE
SVCPLAN-8828: optional env vars, optional exported clients

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -54,7 +54,9 @@ The following parameters are available in the `profile_backup::client` class:
 
 * [`enabled`](#-profile_backup--client--enabled)
 * [`encryption_passphrase`](#-profile_backup--client--encryption_passphrase)
+* [`env_vars`](#-profile_backup--client--env_vars)
 * [`job_cron_schedule`](#-profile_backup--client--job_cron_schedule)
+* [`network_interface`](#-profile_backup--client--network_interface)
 * [`prune_settings`](#-profile_backup--client--prune_settings)
 * [`server_user`](#-profile_backup--client--server_user)
 * [`servers`](#-profile_backup--client--servers)
@@ -76,11 +78,33 @@ Data type: `String`
 
 Encryption passphrase used by the client's backups
 
+##### <a name="-profile_backup--client--env_vars"></a>`env_vars`
+
+Data type: `Hash`
+
+Optionally provide specific additional environment variables to be set/
+exported in the borg_defaults.sh script. These are references in the
+borg_defaults.sh.erb template file. E.g. if the borgbackup and the other
+required Python packages have been installed in /opt/borg/ instead of
+the default system location, you might add this:
+  profile_backup::client::env_vars:
+    PYTHONPATH: "/opt/borg/lib64/python3.6/site-packages:/opt/borg/lib/python3.6/site-packages:$PYTHONPATH"
+    BORG: "/opt/borg/bin/borg"
+
 ##### <a name="-profile_backup--client--job_cron_schedule"></a>`job_cron_schedule`
 
 Data type: `Hash`
 
 Cron settings for backup jobs
+
+##### <a name="-profile_backup--client--network_interface"></a>`network_interface`
+
+Data type: `Optional[String]`
+
+Optional. The name of the network interface (e.g., eth0, ib0) that the client
+will use to SSH to the backup server. Use this to get the client to export
+an IP address that is different from the default IP address that facter
+determines.
 
 ##### <a name="-profile_backup--client--prune_settings"></a>`prune_settings`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,9 +1,16 @@
 ---
 profile_backup::client::enabled: true
 profile_backup::client::encryption_passphrase: "CHANGE ME"
+profile_backup::client::env_vars: {}
+# example data you might use if borgbackup and the other required Python
+# packages were installed in /opt/borg/ instead of the default system location:
+#profile_backup::client::env_vars:
+#  PYTHONPATH: "/opt/borg/lib64/python3.6/site-packages:/opt/borg/lib/python3.6/site-packages:$PYTHONPATH"
+#  BORG: "/opt/borg/bin/borg"
 profile_backup::client::job_cron_schedule:
   hour: 0
   minute: 30
+profile_backup::client::network_interface: null
 profile_backup::client::prune_settings:
   "keep-hourly": 1
   "keep-daily": 7
@@ -33,6 +40,7 @@ profile_backup::server::additional_sshd_match_params:
 profile_backup::server::allow_client_requires: []
 profile_backup::server::backup_directory: null
 profile_backup::server::clients: {}
+profile_backup::server::exported_clients: true
 profile_backup::server::gid: null
 profile_backup::server::groupname: "nobody"
 profile_backup::server::storage_dependencies: []

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -6,8 +6,24 @@
 # @param encryption_passphrase
 #   Encryption passphrase used by the client's backups
 #
+# @param env_vars
+#   Optionally provide specific additional environment variables to be set/
+#   exported in the borg_defaults.sh script. These are references in the
+#   borg_defaults.sh.erb template file. E.g. if the borgbackup and the other
+#   required Python packages have been installed in /opt/borg/ instead of
+#   the default system location, you might add this:
+#     profile_backup::client::env_vars:
+#       PYTHONPATH: "/opt/borg/lib64/python3.6/site-packages:/opt/borg/lib/python3.6/site-packages:$PYTHONPATH"
+#       BORG: "/opt/borg/bin/borg"
+#
 # @param job_cron_schedule
 #   Cron settings for backup jobs
+#
+# @param network_interface
+#   Optional. The name of the network interface (e.g., eth0, ib0) that the client
+#   will use to SSH to the backup server. Use this to get the client to export
+#   an IP address that is different from the default IP address that facter
+#   determines.
 #
 # @param prune_settings
 #   Settings used for pruning client's backup data
@@ -38,7 +54,9 @@
 class profile_backup::client (
   Boolean $enabled,
   String $encryption_passphrase,
+  Hash $env_vars,
   Hash $job_cron_schedule,
+  Optional[String] $network_interface,
   Hash $prune_settings,
   String $server_user,
   Array[String] $servers,
@@ -162,10 +180,16 @@ class profile_backup::client (
       ],
     }
 
+    if $network_interface {
+      $ip_address = $facts['networking']['interfaces']["$network_interface"]['ip']
+    } else {
+      $ip_address = $facts['networking']['ip']
+    }
+
     # EXPORT CLIENT DETAILS TO BACKUP SERVER FOR ACCESS
     @@profile_backup::server::allow_client { "allow host ${facts['networking']['fqdn']} access to backup servers":
       hostname     => $facts['networking']['fqdn'],
-      ip           => $facts['networking']['ip'],
+      ip           => $ip_address,
       ssh_key_pub  => $ssh_key_pub,
       ssh_key_type => $ssh_key_type,
       tag          => 'profile_backup_allow_client',

--- a/templates/borg_defaults.sh.erb
+++ b/templates/borg_defaults.sh.erb
@@ -8,6 +8,9 @@ export BORG_RSH='ssh -i <%= @sshdir %>/backup_id_<%= @ssh_key_type %> -o StrictH
 export BORG_PASSPHRASE='<%= @encryption_passphrase %>'
 export BORG_PRUNE_OPTIONS='<%= @prune_options_string %>'
 export BORG_RELOCATED_REPO_ACCESS_IS_OK=yes
+<% @env_vars.each do | key, value | -%>
+export <%= key %>=<%= value %>
+<% end -%>
 
 SERVER_LIST='<%= @server_list %>'
 # CHOOSE BACKUP SERVER THAT IS RESPONDING


### PR DESCRIPTION
Allow setting additional environment variables in borg_defaults.sh via profile_backup::client::env_vars. Use cases were:
- expand PYTHONPATH
- override BORG path These help when pip packages need to be installed in alternate locations.

Allow disabling use of exported clients.
- The clients on the mg cluster were registering themselves with their mgmt IPs and we'd rather use IB for backup, when possible.